### PR TITLE
Fixed all file endings that are not tar.gz

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function getFileEnding(file) {
     if (file.endsWith('.tar.gz')) {
         return '.tar.gz';
     } else {
-        return file.slice((file.lastIndexOf('.') - 1 >>> 0) + 2);
+        return file.slice((file.lastIndexOf('.') >>> 0));
     }
 }
 


### PR DESCRIPTION
Seems the way you extract the file ending removes the "." before the extension, therefore any compressed file that is not `.tar.gz` (as you hardcoded that one) will self-report as `zip` or `7z`.

When comparing extensions to map the correct function, you are using `.zip` or `.7z`, so the comparison fails, and the action returns an exception.